### PR TITLE
Foxglove combined

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,7 @@ docker compose up
 
 Open the **Google Chrome** browser on your laptop and navigate to:
 
-http://rosbot2r:8080
-
-In the left column, click the **[+]** button adjacent to Data source. This will display:
-
-![foxglove data source](docs/foxglove-datasource.png)
-
-Next, select the **[Open connection]** button, revealing:
-
-![foxglove new connection](docs/foxglove-new-connection.png)
-
-The `WebSocket URL` field should already be populated. Simply press the **[Open]** button, and the web UI of your ROSbot will appear:
+http://rosbot2r:8080/ui
 
 ![foxglove UI](docs/foxglove-ui.png)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - ./params/RosbotTeleop.json:/src/FoxgloveDefaultLayout.json
+      - ./params/RosbotTeleop.json:/foxglove/default-layout.json
     environment:
       - DS_TYPE=rosbridge-websocket
       - DS_PORT=9090

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,14 +1,17 @@
 services:
 
   foxglove:
-    image: husarion/foxglove:humble-1.39.1-20230220
+    image: husarion/foxglove:1.74.1
     ports:
       - 8080:8080
     volumes:
       - ./params/RosbotTeleop.json:/src/FoxgloveDefaultLayout.json
     environment:
-      - FOXGLOVE_PORT=8080
-      - ROSBRIDGE_PORT=9090
+      - DS_TYPE=rosbridge-websocket
+      - DS_PORT=9090
+      - UI_PORT=8080
+      - DISABLE_CACHE=true
+      - DISABLE_INTERACTION=false
 
   rosbridge:
     image: husarion/rosbridge-server:humble-1.3.1-20230505-stable
@@ -17,27 +20,21 @@ services:
     command: ros2 launch rosbridge_server rosbridge_websocket_launch.xml  
 
   rosbot:
-    image: husarion/rosbot:humble-0.6.1-20230712
-    command: ros2 launch rosbot_bringup bringup.launch.py
-
-  microros:
-    image: husarion/micro-xrce-agent:v2.4.1
+    image: husarion/rosbot:humble-0.11.0-20231211
     devices:
       - ${SERIAL_PORT:?err}
-    command: MicroXRCEAgent serial -D $SERIAL_PORT serial -b 576000
+    command: >
+      ros2 launch rosbot_bringup combined.launch.py 
+        mecanum:=${MECANUM:-False}
+        serial_port:=$SERIAL_PORT 
+        serial_baudrate:=576000
 
   astra:
-    image: husarion/astra:humble-1.0.2-20230710-stable
+    image: husarion/astra:humble-1.0.2-20231206-stable
     devices:
       - /dev/bus/usb/
     volumes:
       - ./params/astra.yaml:/ros2_ws/install/astra_camera/share/astra_camera/params/astra_mini_params.yaml
     command: ros2 launch astra_camera astra_mini.launch.py
 
-  image_compressor:
-    image: husarion/image-transport:humble-4.2.0-20230216
-    command: >
-      ros2 run image_transport republish raw compressed
-        --ros-args
-        --remap in:=/camera/color/image_raw
-        --remap out/compressed:=/camera/color/image_raw/compressed
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,17 +7,25 @@ services:
     volumes:
       - ./params/RosbotTeleop.json:/foxglove/default-layout.json
     environment:
-      - DS_TYPE=rosbridge-websocket
-      - DS_PORT=9090
+      # - DS_TYPE=rosbridge-websocket
+      # - DS_PORT=9090
+      - DS_TYPE=foxglove-websocket
+      - DS_PORT=8765
       - UI_PORT=8080
       - DISABLE_CACHE=true
       - DISABLE_INTERACTION=false
 
-  rosbridge:
-    image: husarion/rosbridge-server:humble-1.3.1-20230831-stable
+  # rosbridge-ds:
+  #   image: husarion/rosbridge-server:humble-1.3.1-20230831-stable
+  #   ports:
+  #     - 9090:9090
+  #   command: ros2 launch rosbridge_server rosbridge_websocket_launch.xml  
+
+  foxglove-ds:
+    image: husarion/foxglove-bridge:humble-0.7.3-20231213
     ports:
-      - 9090:9090
-    command: ros2 launch rosbridge_server rosbridge_websocket_launch.xml  
+      - 8765:8765
+    command: ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765 capabilities:=[clientPublish,connectionGraph,assets]
 
   rosbot:
     image: husarion/rosbot:humble-0.11.0-20231211

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
       - DISABLE_INTERACTION=false
 
   rosbridge:
-    image: husarion/rosbridge-server:humble-1.3.1-20230505-stable
+    image: husarion/rosbridge-server:humble-1.3.1-20230831-stable
     ports:
       - 9090:9090
     command: ros2 launch rosbridge_server rosbridge_websocket_launch.xml  

--- a/flash_rosbot_firmware.sh
+++ b/flash_rosbot_firmware.sh
@@ -1,41 +1,10 @@
 #!/bin/bash
 
-get_arch() {
-ARCH=$(uname -m)
-
-case $ARCH in
-    x86_64)
-        echo "amd64"
-        ;;
-    aarch64)
-        echo "arm64"
-        ;;
-    *)
-        echo "Unknown architecture"
-        ;;
-esac
-}
-
-# Check if yq is installed
-if ! command -v /usr/bin/yq &> /dev/null; then
-    # Check if the user is root
-    if [ "$EUID" -ne 0 ]; then
-        echo "Please run as root to install yq"
-        exit 1
-    fi
-    
-    YQ_VERSION=v4.35.1
-    curl -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_$(get_arch) -o /usr/bin/yq
-    chmod +x /usr/bin/yq
-else
-    echo "/usr/bin/yq is already installed"
-fi
-
 echo "stopping all running containers"
-docker stop $(docker ps -q)
+docker stop rosbot
 
 echo "flashing the firmware for STM32 microcontroller in ROSbot"
 docker run \
 --rm -it --privileged \
 $(yq .services.rosbot.image compose.yaml) \
-/flash-firmware.py /root/firmware.bin
+ros2 run rosbot_utils flash_firmware

--- a/flash_rosbot_firmware.sh
+++ b/flash_rosbot_firmware.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "stopping all running containers"
+echo "stopping rosbot container"
 docker stop rosbot
 
 echo "flashing the firmware for STM32 microcontroller in ROSbot"


### PR DESCRIPTION
- using `husarion/foxglove:1.74.1`
- using `husarion/foxglove-bridge:humble-0.7.3-20231213`
- using `combined.bringup.launch` for ROSbot (to launch both MicroROS Agent and ROSbot ROS 2 driver)